### PR TITLE
Demon spikes

### DIFF
--- a/src/common/SPELLS/demonhunter.ts
+++ b/src/common/SPELLS/demonhunter.ts
@@ -169,7 +169,7 @@ const spells = {
     icon: 'ability_demonhunter_immolation',
   },
   INFERNAL_STRIKE: {
-    id: 189110,
+    id: 189112,
     name: 'Infernal Strike',
     icon: 'ability_demonhunter_infernalstrike1',
   },

--- a/src/common/SPELLS/demonhunter.ts
+++ b/src/common/SPELLS/demonhunter.ts
@@ -169,7 +169,7 @@ const spells = {
     icon: 'ability_demonhunter_immolation',
   },
   INFERNAL_STRIKE: {
-    id: 189112,
+    id: 189110,
     name: 'Infernal Strike',
     icon: 'ability_demonhunter_infernalstrike1',
   },

--- a/src/parser/demonhunter/vengeance/CHANGELOG.js
+++ b/src/parser/demonhunter/vengeance/CHANGELOG.js
@@ -2,6 +2,7 @@ import { Zeboot, LeoZhekov, TurianSniper, Geeii } from 'CONTRIBUTORS';
 import { change, date } from 'common/changelog';
 
 export default [
+  change(date(2020, 12, 28), 'Updated Demonic Spikes, implemented Infernal Strikes (but disabling due to blizzard bug)', Geeii),
   change(date(2020, 12, 27), 'Updated to use Fury resource, instead of outdated Pain. Updated Soul Cleave reporting, updated ability tracking for Sigil of Flame for some cases', Geeii),
   change(date(2020, 12, 27), 'Initial SL update for talent changes and covenant abilities', TurianSniper),
   change(date(2020, 10, 30), 'Replaced the deprecated StatisticBox with the new Statistic', LeoZhekov),

--- a/src/parser/demonhunter/vengeance/CombatLogParser.js
+++ b/src/parser/demonhunter/vengeance/CombatLogParser.js
@@ -27,6 +27,7 @@ import ImmolationAura from './modules/spells/ImmolationAura';
 import DemonSpikes from './modules/spells/DemonSpikes';
 import SigilOfFlame from './modules/spells/SigilOfFlame';
 import SoulCleaveSoulsConsumed from './modules/spells/SoulCleaveSoulsConsumed';
+import InfernalStrike from './modules/spells/InfernalStrike';
 
 class CombatLogParser extends CoreCombatLogParser {
   static specModules = {
@@ -59,6 +60,7 @@ class CombatLogParser extends CoreCombatLogParser {
     sigilOfFlame: SigilOfFlame,
     soulCleaveSoulsConsumed: SoulCleaveSoulsConsumed,
     voidReaverDebuff: VoidReaverDebuff,
+    infernalStrike: InfernalStrike,
 
     // Stats
     soulsOvercap: SoulsOvercap,

--- a/src/parser/demonhunter/vengeance/modules/Abilities.js
+++ b/src/parser/demonhunter/vengeance/modules/Abilities.js
@@ -180,6 +180,7 @@ class Abilities extends CoreAbilities {
         category: Abilities.SPELL_CATEGORIES.UTILITY,
         cooldown: combatant.hasTalent(SPELLS.ABYSSAL_STRIKE_TALENT.id) ? 12 : 20,
         charges: 2,
+        enabled: false, // TODO: change this to true, when infernal strike logging is working, see infernalstrike module for more details.
       },
 
       {
@@ -229,7 +230,7 @@ class Abilities extends CoreAbilities {
         gcd: null,
       },
 	  
-	  // Covenant (move these if needed)
+	    // Covenant (move these if needed)
       {
         spell: SPELLS.ELYSIAN_DECREE,
         category: Abilities.SPELL_CATEGORIES.ROTATIONAL_AOE,

--- a/src/parser/demonhunter/vengeance/modules/spells/DemonSpikes.js
+++ b/src/parser/demonhunter/vengeance/modules/spells/DemonSpikes.js
@@ -27,9 +27,9 @@ class DemonSpikes extends Analyzer {
     return {
       actual: this.hitsWithDSOffCDPercent,
       isGreaterThan: {
-        minor: 0.20,
-        average: 0.30,
-        major: 0.40,
+        minor: 0.75,
+        average: 0.70,
+        major: 0.650,
       },
       style: 'percentage',
     };


### PR DESCRIPTION
## What this does
- Fixes Demon Spikes minor, average, and major uptime thresholds
- Implemented (but disabled) a Infernal Strikes module. Issues on Blizzard's end prevent this from being used.